### PR TITLE
Add new Artillery scenario file and add variables for query params

### DIFF
--- a/app/src/routes/metar.js
+++ b/app/src/routes/metar.js
@@ -23,7 +23,8 @@ router.get('/metar', async (req, res, next) => {
                 requestType: "retrieve",
                 format: "xml",
                 stationString: station,
-                hoursBeforeNow: 1
+                hoursBeforeNow: 1,
+                mostRecent: true,
             }
         }).then((response) => {
             const parsed = parser.parse(response.data);

--- a/perf/metar.yaml
+++ b/perf/metar.yaml
@@ -1,0 +1,36 @@
+config:
+  environments:
+    api:
+      target: 'http://localhost:5555/api'
+      plugins:
+        statsd:
+          host: localhost
+          port: 8125
+          prefix: "artillery-api"
+
+  pool: 50 # All HTTP requests from all virtual users will be sent over the same connections
+
+  phases:
+    - name: Ramp
+      duration: 30
+      arrivalRate: 1
+      rampTo: 5
+    - name: Plain
+      duration: 60
+      arrivalRate: 5
+
+  variables:
+    station:
+      - "SAEZ"
+      - "KDEW"
+      - "EDDB"
+      - "WIDD"
+      - "SBGL"
+      - "KSEA"
+    
+
+scenarios:
+  - name: METAR (/metar)
+    flow:
+      - get:
+          url: '/metar?station={{ station }}'

--- a/perf/package.json
+++ b/perf/package.json
@@ -7,6 +7,7 @@
     "artillery": "artillery",
     "node": "artillery run root.yaml -e api",
     "load": "artillery run load.yaml -e api",
+    "metar": "artillery run metar.yaml -e api",
     "scenario": "./run-scenario.sh"
   },
   "author": "",


### PR DESCRIPTION
Agrega variables en escenario de Artillery, para generar requests con parámetros al azar durante las pruebas.
Requerimiento:
>Tengan en cuenta que, en el caso de los METARs, la carga generada debe enviar distintos códigos de aeródromo cuando simulen los pedidos de los clientes.